### PR TITLE
Save config.yaml to run output folder (closes #19)

### DIFF
--- a/scripts/workstream-1-main.py
+++ b/scripts/workstream-1-main.py
@@ -6,7 +6,7 @@ import sys
 import logging
 from fft_project.simulation_gamble_data import simulate_gamble_data
 from fft_project.config import read_dotenv, parse_args, read_config_file, setup_logging
-from fft_project.config import setup_run_id, setup_output_folders
+from fft_project.config import setup_run_id, setup_output_folders, save_config
 from fft_project.simulation_gamble_data import simulate_gamble_data
 
 def main():
@@ -35,7 +35,8 @@ def main():
   # Set up output folders
   setup_output_folders(REMOTE_DRIVE, config["run_id"])
 
-  # Save the config file to the output folder for record-keeping
+  # Save config file to the run's input folder
+  save_config(args.config, REMOTE_DRIVE, config["run_id"])
 
   # Simulate gamble data
   generated_data_folder_path = f"{REMOTE_DRIVE}/{config['run_id']}/2-generated-data"

--- a/src/fft_project/config.py
+++ b/src/fft_project/config.py
@@ -83,3 +83,17 @@ def setup_output_folders(remote_drive, run_id,):
             logger.warning(f"Subfolder already exists: {subfolder_path}")
 
     return
+
+
+def save_config(config_path, remote_drive, run_id):
+    """
+    Copies the config file used for a run to the run's 1-inputs folder,
+    so it is clear what settings were used when the run was executed.
+    """
+    import shutil
+    from pathlib import Path
+
+    # Build the destination path inside the run's 1-inputs subfolder
+    destination = Path(remote_drive) / run_id / "1-inputs" / "config.yaml"
+    shutil.copy(config_path, destination)
+    logger.info(f"Config file saved to: {destination}")


### PR DESCRIPTION
## Summary
- Added `save_config` function to `config.py` that copies the config file to the run's `1-inputs` folder
- Called `save_config` in `workstream-1-main.py` after the output folders are set up

## Test plan
- [x] Run `workstream-1-main.py` and verify `config.yaml` appears in `{REMOTE_DRIVE}/{run_id}/1-inputs/`
- [x] Verify logging output confirms the file was saved