### PR TITLE
Add maximum likelihood / MAP eta estimation

### DIFF
--- a/docs/docs/eta-estimation.md
+++ b/docs/docs/eta-estimation.md
@@ -16,7 +16,7 @@ $$
 
 The parameter $\eta$ controls the curvature of this transformation and
 therefore how a participant values outcomes. At $\eta = 0$ the
-transformation is linear — the participant cares about the expected
+transformation is linear, so the participant cares about the expected
 value of a gamble and treats gains and losses symmetrically. At $\eta = 1$
 it becomes logarithmic, which is the growth-optimal strategy under
 multiplicative dynamics. As $\eta$ increases beyond 1, large outcomes are
@@ -39,7 +39,7 @@ $$
 This is the same thing written as $\Delta\langle\delta f_\eta\rangle$ further
 down.
 
-A fast-and-frugal tree decides in like this, once a cue fires, it picks the side with the higher value. What we use here is a softer version of that, the participant picks the better side most of the time, but not always. How strict this is depends on beta, the bigger beta gets, the closer we are to the hard rule of the tree. In that sense the tree is just the extreme case.
+A fast-and-frugal tree decides like this: once a cue fires, it picks the side with the higher value. What we use here is a softer version of that, the participant picks the better side most of the time, but not always. How strict this is depends on beta, the bigger beta gets, the closer we are to the hard rule of the tree. In that sense the tree is just the extreme case.
 
 This only holds  as long as there is a single cue. Estimating eta like this
 assumes the utility cue is the only thing behind a choice. As soon as a tree
@@ -68,7 +68,7 @@ are unknown and estimated simultaneously.
 
 The logistic function gives the probability $\theta_t$ of a single choice. To
 estimate $\eta$, the probability of the entire sequence of observed choices is
-needed — and the Bernoulli distribution provides the link.
+needed, and the Bernoulli distribution provides the link.
 
 Each trial has exactly two outcomes (left or right), so each choice is modelled
 as a Bernoulli trial:
@@ -100,53 +100,37 @@ $$
 \log p(\text{data} \mid \eta, \beta) = \sum_{t=1}^{T}\big[\,y_t\log\theta_t + (1-y_t)\log(1-\theta_t)\,\big]
 $$
 
-This is the term $p(\text{data} \mid \eta, \beta)$ that enters Bayes' theorem
-below.
+## Maximum likelihood estimate
 
-## Bayesian estimation
-
-The goal is to find which values of $\eta$ are consistent with the
-observed choices. Bayesian inference does this by combining prior knowledge
-and the data into a posterior distribution that reflects all plausible values
-of $\eta$ along with their relative probability.
+We estimate $\eta$ and $\beta$ by maximising the log-likelihood above:
 
 $$
-p(\eta, \beta \mid \text{data}) \propto p(\text{data} \mid \eta, \beta) \times p(\eta, \beta)
+(\hat\eta, \hat\beta) = \arg\max_{\eta,\,\beta}\; \log p(\text{data} \mid \eta, \beta)
 $$
 
-The **prior** $p(\eta, \beta)$ represents what is assumed before seeing
-any choices. Weakly informative priors are used — $\eta$ is normally
-distributed over a broad range, $\beta$ is log-normally distributed —
-so that the estimates are driven by the data rather than prior assumptions.
+There is no closed form, but with only two parameters a numerical optimiser
+(Nelder-Mead) converges quickly. We optimise over $\log\beta$ to keep $\beta$
+positive and fit each participant separately, giving one $\hat\eta$ per
+participant and condition. $\beta$ acts as a nuisance parameter that absorbs
+choice noise, so $\hat\eta$ reflects the preferred side rather than the
+consistency of the choices.
 
-The **likelihood** $p(\text{data} \mid \eta, \beta)$ is the Bernoulli product
-defined above. It measures how well a candidate $(\eta, \beta)$ pair predicts
-the participant's actual choices. If a particular $\eta$ consistently predicts
-the gamble the participant chose, it receives a high likelihood.
+## MAP with weak priors
 
-The **posterior** is the combination of both. Rather than returning a
-single number, it is a full distribution showing which $\eta$ values are
-plausible given the data. The peak of this distribution — the Maximum a
-Posteriori (MAP) estimate — is used as the point estimate per participant.
+For near-separable choices the likelihood is maximised as $\beta \to \infty$
+with $\eta$ diverging. We regularise by maximising the log-posterior instead,
 
-## MCMC sampling
+$$
+(\hat\eta, \hat\beta) = \arg\max_{\eta,\,\beta}\;\big[\log p(\text{data} \mid \eta, \beta) + \log p(\eta, \beta)\big]
+$$
 
-The posterior has no closed-form solution and is instead approximated
-using Markov Chain Monte Carlo (MCMC) sampling via JAGS. The sampler
-generates a large collection of $(\eta, \beta)$ values by exploring the
-parameter space, spending more time in regions where the parameters fit
-the data well. Four independent chains with 10,000 samples each are run,
-discarding the first 1,000 as burn-in. Convergence is verified using the
-Gelman-Rubin R-hat statistic, which should fall between 1 and 1.01.
+with weak priors (a broad normal on $\eta$, a log-normal on $\beta$).
+Dropping the priors recovers the MLE.
 
-## Hierarchical estimation
+## What we leave out for now
 
-Rather than estimating $\eta$ for each participant completely
-independently, a hierarchical (partial pooling) model is used. All
-individual $\eta$ values are assumed to come from the same group-level
-distribution, whose mean and variance are estimated from the full dataset.
-As a result, each participant's estimate is informed not only by their own
-choices, but also by what is typical across the group. This is
-particularly useful when a participant's choices are noisy: instead of
-producing an unreliable individual estimate, the model falls back on the
-group mean. This process is known as shrinkage.
+We use the same likelihood as the paper but skip the hierarchical Bayesian
+model and MCMC (JAGS). That would add full posteriors per participant and
+partial pooling across participants (shrinkage for noisy participants).
+Neither is needed for a first per-participant point estimate, so we defer it.
+The hierarchical model can be added later on top of the same likelihood.

--- a/scripts/test-scripts/eta-estimation-test.py
+++ b/scripts/test-scripts/eta-estimation-test.py
@@ -1,0 +1,105 @@
+# Estimate the risk aversion parameter eta from the experimental choice data,
+# using the simple maximum likelihood / MAP method (no MCMC).
+#
+# It prints:
+#   1. a pooled eta per condition (all choices treated as one participant), and
+#   2. a per-participant eta for the additive and multiplicative conditions,
+#      with a short summary.
+#
+# Sanity check: the mean/median eta should be markedly higher under the
+# multiplicative condition than under the additive one -- the central finding
+# of the paper.
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+import numpy as np
+import pandas as pd
+
+from fft_project.prepare_experimental_data import prepare_experimental_data
+from fft_project.eta_estimation import estimate_eta, estimate_eta_per_participant
+
+SELECTED_SIDE = ("experiment_a", 1, "selected_side")  # column label pattern
+
+
+def _choices_and_wealth(gamble_data, results, fft_id):
+    # Pull the observed choices and pre-choice wealth for a condition, aligned
+    # with the gamble_data rows.
+    choices = results[(fft_id, 1, "selected_side")].to_numpy()
+    wealth = gamble_data["wealth"].to_numpy(dtype=float)
+    return choices, wealth
+
+
+def main():
+    gamble_data, results = prepare_experimental_data(
+        PROJECT_ROOT / "data/all_active_phase_data.csv"
+    )
+    gamble_add, gamble_mul = gamble_data
+    results_add, results_mul = results
+
+    conditions = [
+        ("additive", gamble_add, results_add, "experiment_a"),
+        ("multiplicative", gamble_mul, results_mul, "experiment_m"),
+    ]
+
+    # 1. Pooled estimate per condition.
+    print("=" * 60)
+    print("Pooled estimate (all choices together)")
+    print("=" * 60)
+    for dynamic, gamble, res, fft_id in conditions:
+        choices, wealth = _choices_and_wealth(gamble, res, fft_id)
+        fit = estimate_eta(gamble, choices, wealth, dynamic, method="map")
+        print(
+            f"{dynamic:>15}: eta = {fit['eta']:+.3f}   "
+            f"beta = {fit['beta']:.3f}   "
+            f"n = {fit['n_trials']}"
+        )
+
+    # 2. Per-participant estimates.
+    print()
+    print("=" * 60)
+    print("Per-participant estimate")
+    print("=" * 60)
+    per_participant = {}
+    for dynamic, gamble, res, fft_id in conditions:
+        choices, wealth = _choices_and_wealth(gamble, res, fft_id)
+        df = estimate_eta_per_participant(
+            gamble,
+            choices,
+            wealth,
+            gamble["participant_id"].to_numpy(),
+            dynamic,
+            method="map",
+        )
+        per_participant[dynamic] = df
+        print(
+            f"{dynamic:>15}: median eta = {df['eta'].median():+.3f}   "
+            f"mean eta = {df['eta'].mean():+.3f}   "
+            f"participants = {len(df)}"
+        )
+
+    # 3. Compare the two conditions per participant.
+    merged = per_participant["additive"].merge(
+        per_participant["multiplicative"],
+        on="participant_id",
+        suffixes=("_add", "_mul"),
+    )
+    higher = (merged["eta_mul"] > merged["eta_add"]).mean()
+    print()
+    print(
+        f"Participants with eta_mul > eta_add: {higher:.0%} "
+        f"(expected: a clear majority)"
+    )
+    print()
+    print("First 10 participants (eta per condition):")
+    print(
+        merged[["participant_id", "eta_add", "eta_mul"]]
+        .head(10)
+        .to_string(index=False)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fft_project/eta_estimation.py
+++ b/src/fft_project/eta_estimation.py
@@ -1,0 +1,228 @@
+# This module estimates the risk aversion parameter eta from observed choices.
+#
+# It implements the simple maximum likelihood / MAP version of the model
+# described in docs/docs/eta-estimation.md: the probability of choosing the
+# left gamble is a logistic function of the difference in expected isoelastic
+# utility between the two gambles, and we find the (eta, beta) pair that best
+# explains the observed choices with a numerical optimiser (no MCMC).
+import logging
+import numpy as np
+from scipy.optimize import minimize
+
+logger = logging.getLogger(__name__)
+
+GAMBLE_COLUMNS = [
+    "gamma_left_up",
+    "gamma_left_down",
+    "gamma_right_up",
+    "gamma_right_down",
+]
+
+# Weakly informative priors used for the MAP estimate. They only rule out
+# absurd values; within a broad range the data decides. eta is normal, and
+# log(beta) is normal (so beta itself is log-normal), mirroring the paper.
+DEFAULT_PRIORS = {
+    "eta_mean": 0.0,
+    "eta_sd": 2.5,
+    "log_beta_mean": 0.0,
+    "log_beta_sd": 1.5,
+}
+
+# Bounds keep the optimiser in a sensible region and prevent overflow in
+# exp(log_beta) for near-separable data.
+_BOUNDS = [(-4.0, 6.0), (-6.0, 8.0)]  # (eta, log_beta)
+
+
+def _mean_isoelastic_utility(up, down, wealth, dynamic, eta):
+    # Mean isoelastic utility of a single gamble (two equally likely outcomes).
+    # Vectorised over trials; identical in meaning to
+    # cue_features.expected_isoelastic_utility.
+    if dynamic == "multiplicative":
+        x1 = np.exp(up) * wealth
+        x2 = np.exp(down) * wealth
+    elif dynamic == "additive":
+        x1 = up + wealth
+        x2 = down + wealth
+    else:
+        raise ValueError("Invalid dynamic. Must be 'multiplicative' or 'additive'.")
+
+    tol = 1e-15
+    if abs(eta - 1) < tol:
+        return (np.log(x1) + np.log(x2)) / 2
+    if abs(eta) < tol:
+        return (x1 + x2) / 2
+    return (np.power(x1, 1 - eta) + np.power(x2, 1 - eta)) / (2 * (1 - eta))
+
+
+def _safe_wealth(gamble_data, wealth, dynamic):
+    # Under additive dynamics an outcome can push wealth to zero or below,
+    # which makes the isoelastic utility undefined. Mirror the safeguard in
+    # analysis_compare.eta_choice: reset such trials to a wealth of 1000.
+    wealth = np.asarray(wealth, dtype=float).copy()
+    if dynamic == "additive":
+        min_outcome = gamble_data[GAMBLE_COLUMNS].to_numpy().min(axis=1)
+        wealth[wealth + min_outcome <= 0] = 1000.0
+    return wealth
+
+
+def _validate_gamble_data(gamble_data):
+    missing = [c for c in GAMBLE_COLUMNS if c not in gamble_data.columns]
+    if missing:
+        logger.error(f"Gamble data is missing required columns: {missing}")
+        raise ValueError(f"Gamble data is missing required columns: {missing}")
+
+
+def _neg_log_posterior(params, delta_f_of_eta, y, priors):
+    # Negative log-posterior (or negative log-likelihood if priors is None).
+    # params = (eta, log_beta). We optimise log_beta so beta stays positive.
+    eta, log_beta = params
+    beta = np.exp(log_beta)
+
+    z = beta * delta_f_of_eta(eta)  # = beta * Delta<delta f_eta>
+
+    # Numerically stable Bernoulli log-likelihood:
+    #   log theta       = -log(1 + e^-z) = -logaddexp(0, -z)
+    #   log(1 - theta)  = -log(1 + e^+z) = -logaddexp(0, +z)
+    log_lik = np.sum(
+        y * (-np.logaddexp(0.0, -z)) + (1.0 - y) * (-np.logaddexp(0.0, z))
+    )
+
+    if priors is not None:
+        log_lik += -0.5 * ((eta - priors["eta_mean"]) / priors["eta_sd"]) ** 2
+        log_lik += -0.5 * ((log_beta - priors["log_beta_mean"]) / priors["log_beta_sd"]) ** 2
+
+    return -log_lik
+
+
+def estimate_eta(
+    gamble_data,
+    choices,
+    wealth,
+    dynamic,
+    method="map",
+    priors=None,
+    n_starts=5,
+    random_seed=0,
+):
+    """
+    Estimate (eta, beta) for one set of choices by maximising the log-likelihood.
+
+    Parameters
+    ----------
+    gamble_data : DataFrame with the four GAMBLE_COLUMNS (gamma values).
+    choices : sequence of "left"/"right", aligned with gamble_data rows.
+    wealth : sequence of wealth-before-choice values, aligned with gamble_data.
+    dynamic : "additive" or "multiplicative".
+    method : "map" (default, weak priors) or "mle" (no priors).
+    priors : dict overriding DEFAULT_PRIORS, or None.
+    n_starts : number of random restarts for the optimiser.
+    random_seed : seed for the restart draws.
+
+    Returns
+    -------
+    dict with keys: eta, beta, n_trials, loglik, success, method.
+    """
+    _validate_gamble_data(gamble_data)
+
+    y = (np.asarray(choices) == "left").astype(float)
+    if len(y) != len(gamble_data) or len(y) != len(wealth):
+        raise ValueError("gamble_data, choices and wealth must have the same length.")
+    if len(y) == 0:
+        raise ValueError("Cannot estimate eta from empty data.")
+
+    w = _safe_wealth(gamble_data, wealth, dynamic)
+
+    # Precompute the gamma arrays once; only eta changes during optimisation.
+    l_up = gamble_data["gamma_left_up"].to_numpy(dtype=float)
+    l_down = gamble_data["gamma_left_down"].to_numpy(dtype=float)
+    r_up = gamble_data["gamma_right_up"].to_numpy(dtype=float)
+    r_down = gamble_data["gamma_right_down"].to_numpy(dtype=float)
+
+    def delta_f_of_eta(eta):
+        # Delta<delta f_eta> = <f_eta(left)> - <f_eta(right)>.
+        # The f_eta(current wealth) term cancels between left and right.
+        return (
+            _mean_isoelastic_utility(l_up, l_down, w, dynamic, eta)
+            - _mean_isoelastic_utility(r_up, r_down, w, dynamic, eta)
+        )
+
+    if method == "map":
+        used_priors = {**DEFAULT_PRIORS, **(priors or {})}
+    elif method == "mle":
+        used_priors = None
+    else:
+        raise ValueError("method must be 'map' or 'mle'.")
+
+    rng = np.random.default_rng(random_seed)
+    starts = [np.array([0.5, 0.0])]
+    for _ in range(max(0, n_starts - 1)):
+        starts.append(np.array([rng.uniform(-2.0, 3.0), rng.uniform(-2.0, 2.0)]))
+
+    best = None
+    for x0 in starts:
+        res = minimize(
+            _neg_log_posterior,
+            x0,
+            args=(delta_f_of_eta, y, used_priors),
+            method="Nelder-Mead",
+            bounds=_BOUNDS,
+        )
+        if best is None or res.fun < best.fun:
+            best = res
+
+    eta_hat, log_beta_hat = best.x
+    # Report the plain log-likelihood (priors excluded) for comparability.
+    loglik = -_neg_log_posterior(best.x, delta_f_of_eta, y, None)
+
+    return {
+        "eta": float(eta_hat),
+        "beta": float(np.exp(log_beta_hat)),
+        "n_trials": int(len(y)),
+        "loglik": float(loglik),
+        "success": bool(best.success),
+        "method": method,
+    }
+
+
+def estimate_eta_per_participant(
+    gamble_data,
+    choices,
+    wealth,
+    participant_ids,
+    dynamic,
+    method="map",
+    priors=None,
+    n_starts=5,
+    random_seed=0,
+):
+    """
+    Run estimate_eta separately for each participant.
+
+    Returns a DataFrame with one row per participant: participant_id, eta,
+    beta, n_trials, loglik, success.
+    """
+    import pandas as pd
+
+    participant_ids = np.asarray(participant_ids)
+    choices = np.asarray(choices)
+    wealth = np.asarray(wealth, dtype=float)
+    gamble_data = gamble_data.reset_index(drop=True)
+
+    rows = []
+    for pid in pd.unique(participant_ids):
+        mask = participant_ids == pid
+        result = estimate_eta(
+            gamble_data.loc[mask],
+            choices[mask],
+            wealth[mask],
+            dynamic,
+            method=method,
+            priors=priors,
+            n_starts=n_starts,
+            random_seed=random_seed,
+        )
+        result["participant_id"] = pid
+        rows.append(result)
+
+    columns = ["participant_id", "eta", "beta", "n_trials", "loglik", "success"]
+    return pd.DataFrame(rows)[columns]


### PR DESCRIPTION
## What this does

Adds a simple way to estimate the risk aversion parameter **eta** per participant from observed choices, using **maximum likelihood / MAP** instead of the hierarchical Bayesian + MCMC (JAGS) machinery.

The probability of choosing the left gamble is the logistic choice model from the paper (eq. 5), based on the difference in expected isoelastic utility. We just maximise that likelihood over `(eta, beta)` with `scipy.optimize` (Nelder-Mead), fitting each participant separately.

## Changes

- **`src/fft_project/eta_estimation.py`** (new) — `estimate_eta` and `estimate_eta_per_participant`. Reuses the isoelastic-utility logic from `cue_features.py`; MAP by default (weak priors: broad normal on eta, log-normal on beta), MLE optional.
- **`scripts/test-scripts/eta-estimation-test.py`** (new) — runs it on `data/all_active_phase_data.csv` and prints pooled + per-participant eta.
- **`docs/docs/eta-estimation.md`** — rewritten so the estimation section describes the ML/MAP method. The hierarchical Bayesian / MCMC approach is kept only as a short "what we leave out for now" note.

## Sanity check on the experimental data

Reproduces the central result of the paper:

- Pooled: eta_add ≈ 0.20, eta_mul ≈ 1.01
- Per participant: median eta_add ≈ 0.43, eta_mul ≈ 0.97
- ~97% of participants have eta_mul > eta_add

## Deliberately left out for now

Full posteriors and partial pooling (shrinkage) from the hierarchical model. The MLE/MAP uses the same likelihood, so the hierarchical version can be layered on later without changing it.